### PR TITLE
feat: add specific block properties based on resource type

### DIFF
--- a/src/main/java/dev/ftb/mods/ftbmaterials/registry/ModBlocks.java
+++ b/src/main/java/dev/ftb/mods/ftbmaterials/registry/ModBlocks.java
@@ -1,8 +1,9 @@
 package dev.ftb.mods.ftbmaterials.registry;
 
 import dev.ftb.mods.ftbmaterials.FTBMaterials;
+import dev.ftb.mods.ftbmaterials.resources.ResourceType;
 import net.minecraft.world.level.block.Block;
-import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.level.block.SoundType;
 import net.neoforged.neoforge.registries.DeferredRegister;
 
 public class ModBlocks {
@@ -12,6 +13,21 @@ public class ModBlocks {
     // see ResourceRegistryHolder for actual block registration
 
     public static Block.Properties defaultProps() {
-        return Block.Properties.of().requiresCorrectToolForDrops().strength(1.5F, 6.0F);
+        return propsFor(null);
+    }
+
+    public static Block.Properties propsFor(ResourceType type) {
+        Block.Properties props = Block.Properties.of().requiresCorrectToolForDrops();
+        if (type == null) {
+            return props.strength(3.0F, 3.0F).sound(SoundType.STONE);
+        }
+        return switch (type) {
+            case DEEPSLATE_ORE -> props.strength(4.5F, 3.0F).sound(SoundType.DEEPSLATE);
+            case NETHER_ORE -> props.strength(3.0F, 3.0F).sound(SoundType.NETHER_ORE);
+            case END_ORE -> props.strength(3.0F, 9.0F).sound(SoundType.STONE);
+            case BLOCK -> props.strength(5.0F, 6.0F).sound(SoundType.METAL);
+            case RAW_BLOCK -> props.strength(5.0F, 6.0F).sound(SoundType.STONE);
+            default -> props.strength(3.0F, 3.0F).sound(SoundType.STONE);
+        };
     }
 }

--- a/src/main/java/dev/ftb/mods/ftbmaterials/resources/ResourceRegistryHolder.java
+++ b/src/main/java/dev/ftb/mods/ftbmaterials/resources/ResourceRegistryHolder.java
@@ -40,7 +40,7 @@ public class ResourceRegistryHolder {
 
             if (resourceType.isBlock()) {
                 DeferredBlock<Block> regBlock = ModBlocks.REGISTRY.register(niceName,
-                        id -> new Block(ModBlocks.defaultProps().setId(ResourceKey.create(Registries.BLOCK, id))));
+                        id -> new Block(ModBlocks.propsFor(resourceType).setId(ResourceKey.create(Registries.BLOCK, id))));
                 DeferredItem<Item> regBlockItem = ModItems.REGISTRY.register(niceName,
                         id -> new BlockItem(regBlock.get(), ModItems.defaultProps().setId(ResourceKey.create(Registries.ITEM, id))));
 


### PR DESCRIPTION
Tailors block strength and sound types to the specific material being registered (for example, deepslate, nether, or metal blocks) rather than using a single generic property set.