### PR TITLE
build: update NeoForge to 26.1.2.22-beta

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -13,8 +13,8 @@ mod_id=ftbmaterials
 
 mod_version=1
 
-neoforge_version=26.1.2.10-beta
-neoforge_version_range=[26.1.2.10-beta,27)
+neoforge_version=26.1.2.22-beta
+neoforge_version_range=[26.1.2.22-beta,27)
 neoforge_loader_version=4
 
 archives_base_name=ftb-materials

--- a/src/main/java/dev/ftb/mods/ftbmaterials/data/LootModifiersGenerator.java
+++ b/src/main/java/dev/ftb/mods/ftbmaterials/data/LootModifiersGenerator.java
@@ -6,6 +6,7 @@ import net.minecraft.core.HolderLookup;
 import net.minecraft.data.PackOutput;
 import net.minecraft.world.level.storage.loot.predicates.LootItemCondition;
 import net.neoforged.neoforge.common.data.GlobalLootModifierProvider;
+import net.neoforged.neoforge.common.loot.IGlobalLootModifier;
 
 import java.util.concurrent.CompletableFuture;
 
@@ -16,6 +17,6 @@ public class LootModifiersGenerator extends GlobalLootModifierProvider {
 
     @Override
     protected void start() {
-        add("unification", new LootTableUnifier(new LootItemCondition[] { }));
+        add("unification", new LootTableUnifier(new LootItemCondition[] { }, IGlobalLootModifier.DEFAULT_PRIORITY));
     }
 }

--- a/src/main/java/dev/ftb/mods/ftbmaterials/unification/LootTableUnifier.java
+++ b/src/main/java/dev/ftb/mods/ftbmaterials/unification/LootTableUnifier.java
@@ -18,8 +18,8 @@ public class LootTableUnifier extends LootModifier {
             builder -> codecStart(builder).apply(builder, LootTableUnifier::new))
     );
 
-    public LootTableUnifier(LootItemCondition[] lootItemConditions) {
-        super(lootItemConditions);
+    public LootTableUnifier(LootItemCondition[] lootItemConditions, int priority) {
+        super(lootItemConditions, priority);
     }
 
     @Override


### PR DESCRIPTION
Adjusts the LootTableUnifier constructor and registration to include the priority parameter